### PR TITLE
add the function used for transfering pending tx to event bus

### DIFF
--- a/rpc/core/mempool.go
+++ b/rpc/core/mempool.go
@@ -26,6 +26,10 @@ func BroadcastTxAsync(ctx *rpctypes.Context, tx types.Tx) (*ctypes.ResultBroadca
 	if err != nil {
 		return nil, err
 	}
+	
+	env.EventBus.PublishEventPendingTx(types.EventDataTx{TxResult: types.TxResult{
+		Tx:     tx,
+	}})
 	return &ctypes.ResultBroadcastTx{Hash: tx.Hash()}, nil
 }
 
@@ -42,6 +46,10 @@ func BroadcastTxSync(ctx *rpctypes.Context, tx types.Tx) (*ctypes.ResultBroadcas
 	}
 	res := <-resCh
 	r := res.GetCheckTx()
+
+	env.EventBus.PublishEventPendingTx(types.EventDataTx{TxResult: types.TxResult{
+		Tx:     tx,
+	}})
 	return &ctypes.ResultBroadcastTx{
 		Code:      r.Code,
 		Data:      r.Data,
@@ -92,6 +100,10 @@ func BroadcastTxCommit(ctx *rpctypes.Context, tx types.Tx) (*ctypes.ResultBroadc
 			Hash:      tx.Hash(),
 		}, nil
 	}
+
+	env.EventBus.PublishEventPendingTx(types.EventDataTx{TxResult: types.TxResult{
+		Tx:     tx,
+	}})
 
 	// Wait for the tx to be included in a block or timeout.
 	select {

--- a/types/event_bus.go
+++ b/types/event_bus.go
@@ -181,6 +181,15 @@ func (b *EventBus) PublishEventTx(data EventDataTx) error {
 	return b.pubsub.PublishWithEvents(ctx, data, events)
 }
 
+func (b *EventBus) PublishEventPendingTx(data EventDataTx) error {
+	ctx := context.Background()
+
+	events := make(map[string][]string)
+	// add predefined compositeKeys
+	events[EventTypeKey] = append(events[EventTypeKey], EventPendingTx)
+	return b.pubsub.PublishWithEvents(ctx, data, events)
+}
+
 func (b *EventBus) PublishEventNewRoundStep(data EventDataRoundState) error {
 	return b.Publish(EventNewRoundStep, data)
 }
@@ -254,6 +263,10 @@ func (NopEventBus) PublishEventVote(data EventDataVote) error {
 }
 
 func (NopEventBus) PublishEventTx(data EventDataTx) error {
+	return nil
+}
+
+func (NopEventBus) PublishEventPendingTx(data EventDataTx) error {
 	return nil
 }
 

--- a/types/events.go
+++ b/types/events.go
@@ -20,6 +20,7 @@ const (
 	EventNewBlock            = "NewBlock"
 	EventNewBlockHeader      = "NewBlockHeader"
 	EventTx                  = "Tx"
+	EventPendingTx           = "PendingTx"
 	EventValidatorSetUpdates = "ValidatorSetUpdates"
 
 	// Internal consensus events.
@@ -167,9 +168,11 @@ type BlockEventPublisher interface {
 	PublishEventNewBlock(block EventDataNewBlock) error
 	PublishEventNewBlockHeader(header EventDataNewBlockHeader) error
 	PublishEventTx(EventDataTx) error
+	PublishEventPendingTx(EventDataTx) error
 	PublishEventValidatorSetUpdates(EventDataValidatorSetUpdates) error
 }
 
 type TxEventPublisher interface {
 	PublishEventTx(EventDataTx) error
+	PublishEventPendingTx(EventDataTx) error
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Try to fix the wrong txhash list fetched from newPendingTransaction api in websocket

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->
In tendermint@v0.39.3 , https://github.com/okex/tendermint/blob/d57afe7b907dc93e00c95eea938986e6c1cfb57c/state/execution.go#L470
the eventBus only iterates the block.Data.Txs, then publishes them, not the pending txs in mempool


______

For contributor use:

- [ ] Wrote tests
- [ ] Updated CHANGELOG_PENDING.md
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments
- [ ] Re-reviewed `Files changed` in the Github PR explorer
