### PR TITLE
abci: replace Mutex to RWMutex for better concurrency (#18)

### DIFF
--- a/abci/client/local_client.go
+++ b/abci/client/local_client.go
@@ -15,18 +15,23 @@ var _ Client = (*localClient)(nil)
 // RPC endpoint), but defers are used everywhere for the sake of consistency.
 type localClient struct {
 	service.BaseService
-
-	mtx *sync.Mutex
+	mtx *sync.RWMutex
+	queryMtx *sync.Mutex
 	types.Application
 	Callback
 }
 
-func NewLocalClient(mtx *sync.Mutex, app types.Application) Client {
+func NewLocalClient(mtx *sync.RWMutex, queryMtx *sync.Mutex, app types.Application) Client {
 	if mtx == nil {
-		mtx = new(sync.Mutex)
+		mtx = new(sync.RWMutex)
 	}
+	if queryMtx == nil {
+		queryMtx = new(sync.Mutex)
+	}
+
 	cli := &localClient{
 		mtx:         mtx,
+		queryMtx: queryMtx,
 		Application: app,
 	}
 	cli.BaseService = *service.NewBaseService(nil, "localClient", cli)
@@ -60,8 +65,8 @@ func (app *localClient) EchoAsync(msg string) *ReqRes {
 }
 
 func (app *localClient) InfoAsync(req types.RequestInfo) *ReqRes {
-	app.mtx.Lock()
-	defer app.mtx.Unlock()
+	app.queryMtx.Lock()
+	defer app.queryMtx.Unlock()
 
 	res := app.Application.Info(req)
 	return app.callback(
@@ -104,8 +109,8 @@ func (app *localClient) CheckTxAsync(req types.RequestCheckTx) *ReqRes {
 }
 
 func (app *localClient) QueryAsync(req types.RequestQuery) *ReqRes {
-	app.mtx.Lock()
-	defer app.mtx.Unlock()
+	app.queryMtx.Lock()
+	defer app.queryMtx.Unlock()
 
 	res := app.Application.Query(req)
 	return app.callback(
@@ -169,8 +174,8 @@ func (app *localClient) EchoSync(msg string) (*types.ResponseEcho, error) {
 }
 
 func (app *localClient) InfoSync(req types.RequestInfo) (*types.ResponseInfo, error) {
-	app.mtx.Lock()
-	defer app.mtx.Unlock()
+	app.queryMtx.Lock()
+	defer app.queryMtx.Unlock()
 
 	res := app.Application.Info(req)
 	return &res, nil
@@ -201,8 +206,8 @@ func (app *localClient) CheckTxSync(req types.RequestCheckTx) (*types.ResponseCh
 }
 
 func (app *localClient) QuerySync(req types.RequestQuery) (*types.ResponseQuery, error) {
-	app.mtx.Lock()
-	defer app.mtx.Unlock()
+	app.queryMtx.Lock()
+	defer app.queryMtx.Unlock()
 
 	res := app.Application.Query(req)
 	return &res, nil

--- a/consensus/common_test.go
+++ b/consensus/common_test.go
@@ -361,7 +361,7 @@ func newStateWithConfigAndBlockStore(
 	blockStore := store.NewBlockStore(blockDB)
 
 	// one for mempool, one for consensus
-	mtx := new(sync.Mutex)
+	mtx := new(sync.RWMutex)
 	proxyAppConnMem := abcicli.NewLocalClient(mtx, app)
 	proxyAppConnCon := abcicli.NewLocalClient(mtx, app)
 

--- a/consensus/reactor_test.go
+++ b/consensus/reactor_test.go
@@ -141,7 +141,7 @@ func TestReactorWithEvidence(t *testing.T) {
 		blockStore := store.NewBlockStore(blockDB)
 
 		// one for mempool, one for consensus
-		mtx := new(sync.Mutex)
+		mtx := new(sync.RWMutex)
 		proxyAppConnMem := abcicli.NewLocalClient(mtx, app)
 		proxyAppConnCon := abcicli.NewLocalClient(mtx, app)
 

--- a/proxy/client.go
+++ b/proxy/client.go
@@ -20,19 +20,21 @@ type ClientCreator interface {
 // local proxy uses a mutex on an in-proc app
 
 type localClientCreator struct {
-	mtx *sync.Mutex
+	mtx *sync.RWMutex
+	queryMtx *sync.Mutex
 	app types.Application
 }
 
 func NewLocalClientCreator(app types.Application) ClientCreator {
 	return &localClientCreator{
-		mtx: new(sync.Mutex),
+		mtx: new(sync.RWMutex),
+		queryMtx: new(sync.Mutex),
 		app: app,
 	}
 }
 
 func (l *localClientCreator) NewABCIClient() (abcicli.Client, error) {
-	return abcicli.NewLocalClient(l.mtx, l.app), nil
+	return abcicli.NewLocalClient(l.mtx, l.queryMtx, l.app), nil
 }
 
 //---------------------------------------------------------------


### PR DESCRIPTION
* remove lock from QuerySync

* abci: replace Mutex to RWMutex for better concurrency

* add Mutex for query

* abci: delete query Lock for faster sync block

* add the function used for transfering pending tx to event bus (#17) (#19)

* add the function used for transfering pending tx to event bus

* go fmt

* rollback gomod

* move eventBus into mempool interface

* go fmt

Co-authored-by: Ray Green <gl12138@live.com>

Co-authored-by: Zhong Qiu <36867992+zhongqiuwood@users.noreply.github.com>
Co-authored-by: Ray Green <gl12138@live.com>

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->


______

For contributor use:

- [ ] Wrote tests
- [ ] Updated CHANGELOG_PENDING.md
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments
- [ ] Re-reviewed `Files changed` in the Github PR explorer
